### PR TITLE
chore: Setup linting workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,78 @@
+name: Lint
+on: workflow_dispatch
+jobs:
+  lint-demo-app:
+    runs-on: runs-on
+    defaults:
+      run:
+        working-directory: demo
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Setup ruby"
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: "Ruby lint"
+        run: bundle exec rubocop --format progress --format github
+
+  lint-engine:
+    runs-on: runs-on
+    defaults:
+      run:
+        working-directory: engine
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Setup ruby"
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: "Ruby lint"
+        run: bundle exec rubocop --format progress --format github
+
+  audit-demo-app:
+    runs-on: runs-on
+    defaults:
+      run:
+        working-directory: demo
+    needs: lint-demo-app
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Setup ruby"
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: "Bundle audit"
+        run: bundle exec bundle-audit
+
+      - name: "Brakeman audit"
+        run: bundle exec brakeman
+
+  audit-engine:
+    runs-on: runs-on
+    defaults:
+      run:
+        working-directory: engine
+    needs: lint-engine
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Setup ruby"
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: "Bundle audit"
+        run: bundle exec bundle-audit
+
+      - name: "Brakeman audit"
+        run: bundle exec brakeman

--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -40,15 +40,17 @@ gem "view_component"
 gem "citizens_advice_cookie_preferences", path: "../engine"
 
 group :development, :test do
-  # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[mri windows], require: "debug/prelude"
-
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false
+
+  gem "bundler-audit"
 
   gem "citizens-advice-style",
       github: "citizensadvice/citizens-advice-style-ruby",
       tag: "v12.0.0"
+
+  # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
+  gem "debug", platforms: %i[mri windows], require: "debug/prelude"
 
   gem "pry"
 end

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -120,6 +120,9 @@ GEM
     brakeman (7.1.0)
       racc
     builder (3.3.0)
+    bundler-audit (0.9.2)
+      bundler (>= 1.2.0, < 3)
+      thor (~> 1.0)
     capybara (3.40.0)
       addressable
       matrix
@@ -395,6 +398,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   brakeman
+  bundler-audit
   citizens-advice-style!
   citizens_advice_components!
   citizens_advice_cookie_preferences!

--- a/engine/Gemfile
+++ b/engine/Gemfile
@@ -14,6 +14,8 @@ gem "sprockets-rails"
 # gem "debug", ">= 1.0.0"
 
 group :development, :test do
+  gem "brakeman", require: false
+  gem "bundler-audit"
   gem "citizens-advice-style", github: "citizensadvice/citizens-advice-style-ruby", tag: "v12.0.0"
   gem "rspec-rails"
 end

--- a/engine/Gemfile.lock
+++ b/engine/Gemfile.lock
@@ -96,7 +96,12 @@ GEM
     base64 (0.3.0)
     benchmark (0.4.1)
     bigdecimal (3.2.2)
+    brakeman (7.1.0)
+      racc
     builder (3.3.0)
+    bundler-audit (0.9.2)
+      bundler (>= 1.2.0, < 3)
+      thor (~> 1.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -305,6 +310,8 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  brakeman
+  bundler-audit
   citizens-advice-style!
   citizens_advice_cookie_preferences!
   puma

--- a/engine/config/routes.rb
+++ b/engine/config/routes.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 CitizensAdviceCookiePreferences::Engine.routes.draw do
+  # TODO: Add initial route
 end


### PR DESCRIPTION
This PR adds a Github workflow to cover linting for both the engine and demo directories.  The linting includes Rubocop, and we've also added Brakeman and Bundler-audit