### PR TITLE
feat: update dependabot package ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,24 @@
 version: 2
 updates:
   - package-ecosystem: bundler
+    directory: "/demo"
+    schedule:
+      interval: weekly
+    ignore:
+      # Design system upgrade should be performed for npm and bundler at the same time, this should happen manually
+      - dependency-name: 'citizens_advice_components'
+      # For Rails, ignore all minor updates for version updates only
+      - dependency-name: "rails"
+        update-types: [ "version-update:semver-minor" ]
+    commit-message:
+      prefix: '[dependabot:bundler:demo] '
+    groups:
+      regular-updates: # Group everything except major version updates and security vulnerabilities
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: bundler
     directory: "/engine"
     schedule:
       interval: weekly
@@ -11,7 +29,35 @@ updates:
       - dependency-name: "rails"
         update-types: [ "version-update:semver-minor" ]
     commit-message:
-      prefix: '[dependabot:bundler] '
+      prefix: '[dependabot:bundler:engine] '
+    groups:
+      regular-updates: # Group everything except major version updates and security vulnerabilities
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: npm
+    directory: '/demo'
+    schedule:
+      interval: weekly
+    ignore:
+      - dependency-name: '@citizensadvice/design-system'
+    commit-message:
+      prefix: '[dependabot:npm:demo] '
+    groups:
+      regular-updates: # Group everything except major version updates and security vulnerabilities
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: npm
+    directory: '/engine'
+    schedule:
+      interval: weekly
+    ignore:
+      - dependency-name: '@citizensadvice/design-system'
+    commit-message:
+      prefix: '[dependabot:npm:engine] '
     groups:
       regular-updates: # Group everything except major version updates and security vulnerabilities
         update-types:


### PR DESCRIPTION
Adds npm to dependabot for `/engine` & `/demo`, also adds bundler for `/demo`