### PR TITLE
Move the cookie preference resource to the engine's root

### DIFF
--- a/engine/app/controllers/citizens_advice_cookie_preferences/cookie_preferences_controller.rb
+++ b/engine/app/controllers/citizens_advice_cookie_preferences/cookie_preferences_controller.rb
@@ -11,7 +11,7 @@ module CitizensAdviceCookiePreferences
     before_action :set_default_cookie, only: :edit
 
     def show
-      redirect_to citizens_advice_cookie_preferences.edit_cookie_preferences_path
+      redirect_to citizens_advice_cookie_preferences.edit_cookie_preference_path
     end
 
     def edit

--- a/engine/app/views/citizens_advice_cookie_preferences/cookie_preferences/edit.html.erb
+++ b/engine/app/views/citizens_advice_cookie_preferences/cookie_preferences/edit.html.erb
@@ -14,7 +14,7 @@
       <p> We’ll only add additional cookies if you give us permission. Additional cookies help us remember your preferences and show you things from other websites, like videos. They also help us find out how you use our website so we can keep improving it.</p>
       <p>You can <a href="/about-us/information/how-we-use-cookies/">read detailed information about how we use cookies.</a></p>
 
-    <%= form_for @cookie_preferences, url: citizens_advice_cookie_preferences.cookie_preferences_path, method: :patch do |form| %>
+    <%= form_for @cookie_preferences, url: citizens_advice_cookie_preferences.cookie_preference_path, method: :patch do |form| %>
       <div class="cads-form-field">
         <fieldset class="cads-form-field__content cads-form-group cads-form-group--radio">
           <legend>

--- a/engine/config/routes.rb
+++ b/engine/config/routes.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
 CitizensAdviceCookiePreferences::Engine.routes.draw do
-  root to: "cookie_preferences#show"
-  resource :cookie_preferences, path: "/cookie-preferences", only: %i[show edit update]
+  resource :cookie_preference, path: "/", only: %i[show edit update]
 end


### PR DESCRIPTION
We can mount the cookie preference page to the engine root, avoiding the ugly `/cookie-preferences/cookie-preferences/edit` path.

I've also updated the routing to use a singular instead of plural resource, and amended the paths used accordingly.