### PR TITLE
chore: Update cookie banner copy [CP-894]

### DIFF
--- a/engine/config/locales/en.yml
+++ b/engine/config/locales/en.yml
@@ -21,4 +21,5 @@ en:
       html: >
         <p>We use essential cookies to make our website work properly.</p>
         <p>We'd also like to use additional cookies to remember your settings and to understand how you use our website. This helps us improve our services for you.</p>
-        <p>Some additional cookies come from other websites. These cookies help us show you things from those websites, like videos.</p>
+        <p>Some additional cookies come from other websites. These cookies help us show you things from those sites, like videos.</p>
+        <p>You can <a href="/about-us/information/how-we-use-cookies/">find out more about the cookies we use</a>.</p>


### PR DESCRIPTION
The final copy for the cookie banner has been approved so we can updated the placeholder text we had

Signed off final copy can be found in this [google doc](https://docs.google.com/document/d/1bgTxlkAfkH_Sd5BDT55W62JHELO9kRIC2P1jnef-iBM/edit?tab=t.yzjom67qgktp)

Current banner copy:
<img width="673" height="355" alt="Screenshot 2025-08-11 at 09 20 02" src="https://github.com/user-attachments/assets/63de5873-ae29-43b9-bb62-0cc5ed346412" />


Updated banner copy:
<img width="718" height="414" alt="Screenshot 2025-08-11 at 09 17 45" src="https://github.com/user-attachments/assets/7c58ea0b-633d-4e7e-905b-8d56bfdf31fa" />
