### PR TITLE
Chore: Update preference page copy [CP-870]

### DIFF
--- a/engine/app/views/citizens_advice_cookie_preferences/cookie_preferences/edit.html.erb
+++ b/engine/app/views/citizens_advice_cookie_preferences/cookie_preferences/edit.html.erb
@@ -3,28 +3,15 @@
     <h1 class="cads-page-title">Your cookie settings</h1>
 
     <div class="cads-prose">
-      <p> We’d like to add small text files called ‘cookies’ to your phone, tablet or computer when you use our website.</p>
-      <p> We use 3 types of cookies. They’re called:</p>
-      <ul>
-        <li>essential cookies</li>
-        <li>analytics cookies</li>
-        <li>video player cookies</li>
-      </ul>
-      <p> We’ll always add essential cookies to your device when you use our website. These cookies make sure our website works properly.</p>
-      <p> We’ll only add additional cookies if you give us permission. Additional cookies help us remember your preferences and show you things from other websites, like videos. They also help us find out how you use our website so we can keep improving it.</p>
-      <p>You can <a href="/about-us/information/how-we-use-cookies/">read detailed information about how we use cookies.</a></p>
+      <%= t("cookie_preferences.summary_html") %>
 
     <%= form_for @cookie_preferences, url: citizens_advice_cookie_preferences.cookie_preference_path, method: :patch do |form| %>
       <div class="cads-form-field">
         <fieldset class="cads-form-field__content cads-form-group cads-form-group--radio">
           <legend>
-            <h2>Accept or reject analytics cookies</h2>
+            <%= t("cookie_preferences.form.analytic_cookies_header_html") %>
           </legend>
-          <p>Analytics text here</p>
-          <p>You might not be able to:</p>
-          <ul>
-            <li>help us improve our website</li>
-          </ul>
+          <%= t("cookie_preferences.form.analytic_cookies_summary_html") %>
           <%= form.collection_radio_buttons :analytics, @cookie_preferences.analytics_cookies_options, :id, :name, required: true, label: "" do |b| %>
             <div class="cads-form-group__item">
               <%= b.radio_button(class: "cads-form-group__input") %>
@@ -37,14 +24,9 @@
       <div class="cads-form-field">
         <fieldset class="cads-form-field__content cads-form-group cads-form-group--radio">
           <legend>
-            <h2>Accept or reject video player cookies</h2>
+            <%= t("cookie_preferences.form.video_player_cookies_header_html") %>
           </legend>
-          <p>Video player text here</p>
-          <p>You might not be able to:</p>
-          <ul>
-            <li>watch embedded videos</li>
-            <li>have your video player preferences remembered</li>
-          </ul>
+          <%= t("cookie_preferences.form.video_player_cookies_summmary_html") %>
           <%= form.collection_radio_buttons :video_players, @cookie_preferences.video_players_cookies_options, :id, :name, required: true, label: "" do |b| %>
             <div class="cads-form-group__item">
               <%= b.radio_button(class: "cads-form-group__input") %>
@@ -55,22 +37,7 @@
       </div>
 
       <%= form.cads_button "Save changes" %>
-
-        <h2>If you'd like to block all cookies</h2>
-        <p>If you block all cookies you won’t be able to:</p>
-        <ul>
-          <li>have your preferences remembered, like what country you live in</li>
-          <li>fill in forms on our website</li>
-          <li>use our chat service</li>
-          <li>see content from other companies like Youtube videos or SurveyMonkey feedback forms</li>
-          <li>log in - if you work or volunteer for Citizens Advice</li>
-        </ul>
-        <p>To block cookies, you should change the settings in your web browser. You can also delete cookies that have already been added. Search for 'cookies' in the ‘Help’ section of your browser.</p>
-        <p>Cookies from Google Analytics or Mouseflow tell us how you're using our site. You can stop these cookies being added to your device by ‘opting out’.</p>
-        <p><a href="https://tools.google.com/dlpage/gaoptout">Opt out from Google Analytics cookies.</a></p>
-        <p><a href="https://mouseflow.com/opt-out/">Opt out from Mouseflow cookies.</a></p>
-
-        <p>You can <a href="https://ico.org.uk/for-the-public/online/cookies/">find out more about cookies and how to delete them on the Information Commissioner's Office (ICO) website.</a></p>
+      <%= t("cookie_preferences.more_info_html") %>
       </div>
     <% end %>
   <% end %>

--- a/engine/app/views/citizens_advice_cookie_preferences/cookie_preferences/edit.html.erb
+++ b/engine/app/views/citizens_advice_cookie_preferences/cookie_preferences/edit.html.erb
@@ -37,8 +37,9 @@
       </div>
 
       <%= form.cads_button "Save changes" %>
-      <%= t("cookie_preferences.more_info_html") %>
-      </div>
+      <%= t("cookie_preferences.change_your_mind_html") %>
     <% end %>
+    <%= t("cookie_preferences.ico_info_html") %>
+    </div>
   <% end %>
 <% end %>

--- a/engine/app/views/citizens_advice_cookie_preferences/cookie_preferences/edit.html.erb
+++ b/engine/app/views/citizens_advice_cookie_preferences/cookie_preferences/edit.html.erb
@@ -1,6 +1,6 @@
 <%= render CitizensAdviceComponents::PageContent.new do |c| %>
   <% c.with_main do %>
-    <h1 class="cads-page-title">Your cookie settings</h1>
+    <h1 class="cads-page-title"><%=t("cookie_preferences.title")%></h1>
 
     <div class="cads-prose">
       <%= t("cookie_preferences.summary_html") %>
@@ -36,7 +36,7 @@
         </fieldset>
       </div>
 
-      <%= form.cads_button "Save changes" %>
+      <%= form.cads_button t("cookie_preferences.form.button_text") %>
       <%= t("cookie_preferences.change_your_mind_html") %>
     <% end %>
     <%= t("cookie_preferences.ico_info_html") %>

--- a/engine/config/locales/en.yml
+++ b/engine/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
         <p>Some additional cookies come from other websites. These cookies help us show you things from those sites, like videos.</p>
         <p>You can <a href="/about-us/information/how-we-use-cookies/">find out more about the cookies we use</a>.</p>
   cookie_preferences:
+    title: Your cookie settings
     summary_html: >
       <p>We add small text files called ‘cookies’ to your phone, tablet or computer when you use our website.</p>
       <p>We use 2 types of cookies:</p>
@@ -55,6 +56,7 @@ en:
         <p>We use these cookies so you can watch videos on our site from places like YouTube.</p> 
         <p>If you accept these cookies, you can watch videos and the player will remember your preferences, like the volume. The cookies will also remember which videos you've watched and how many times you watched them. If you don’t accept these cookies, you won’t be able to watch videos on our site.</p>
         <p>YouTube adds their own analytics cookies to your device even if you’ve rejected our analytics cookies.</p>
+      button_text: Save changes
     change_your_mind_html: >
       <p>You can change your mind about additional cookies at any time by coming back to this page.</p>
     ico_info_html: >

--- a/engine/config/locales/en.yml
+++ b/engine/config/locales/en.yml
@@ -55,7 +55,8 @@ en:
         <p>We use these cookies so you can watch videos on our site from places like YouTube.</p> 
         <p>If you accept these cookies, you can watch videos and the player will remember your preferences, like the volume. The cookies will also remember which videos you've watched and how many times you watched them. If you don’t accept these cookies, you won’t be able to watch videos on our site.</p>
         <p>YouTube adds their own analytics cookies to your device even if you’ve rejected our analytics cookies.</p>
-    more_info_html: >
+    change_your_mind_html: >
       <p>You can change your mind about additional cookies at any time by coming back to this page.</p>
+    ico_info_html: >
       <p>You can <a href="https://ico.org.uk/for-the-public/online/cookies/">find out more about cookies and how to delete them on the Information Commissioner's Office (ICO) website.</a></p>
 

--- a/engine/config/locales/en.yml
+++ b/engine/config/locales/en.yml
@@ -23,3 +23,39 @@ en:
         <p>We'd also like to use additional cookies to remember your settings and to understand how you use our website. This helps us improve our services for you.</p>
         <p>Some additional cookies come from other websites. These cookies help us show you things from those sites, like videos.</p>
         <p>You can <a href="/about-us/information/how-we-use-cookies/">find out more about the cookies we use</a>.</p>
+  cookie_preferences:
+    summary_html: >
+      <p>We add small text files called ‘cookies’ to your phone, tablet or computer when you use our website.</p>
+      <p>We use 2 types of cookies:</p>
+      <ul>
+        <li>essential cookies - we have to use these to make our website work</li>
+        <li>additional cookies - we’ll only use these if you give us your permission</li>
+      </ul>
+      <p>You can see <a href="/about-us/information/how-we-use-cookies/"> a full list of all the cookies we use</a>.</p>
+      <h2>Essential cookies</h2>
+      <p>We add essential cookies to your device as soon as you use our website. Without them our website won’t work properly.</p>
+      <p>You can block essential cookies in your browser settings, but you won’t be able to:</p>
+      <ul>
+        <li>save your preferences, like the country you live in</li>
+        <li>fill in forms on our website</li>
+        <li>use our online chat service</li>
+        <li>log in, if you work or volunteer for us</li>
+      </ul>
+      <h2>Additional cookies</h2>
+      <p>We won't add additional cookies unless you give us permission.</p>
+    form:
+      analytic_cookies_header_html: >
+        <h2>Accept or reject analytics cookies</h2>
+      analytic_cookies_summary_html: >
+        <p>These cookies help us improve our website by showing us how people use it. For example, which pages are most popular or where people are having problems.</p> 
+        <p>We use tools like Google Analytics and Mouseflow to see how people are using our site.</p>
+      video_player_cookies_header_html: >
+        <h2>Accept or reject video player cookies</h2>
+      video_player_cookies_summmary_html: >
+        <p>We use these cookies so you can watch videos on our site from places like YouTube.</p> 
+        <p>If you accept these cookies, you can watch videos and the player will remember your preferences, like the volume. The cookies will also remember which videos you've watched and how many times you watched them. If you don’t accept these cookies, you won’t be able to watch videos on our site.</p>
+        <p>YouTube adds their own analytics cookies to your device even if you’ve rejected our analytics cookies.</p>
+    more_info_html: >
+      <p>You can change your mind about additional cookies at any time by coming back to this page.</p>
+      <p>You can <a href="https://ico.org.uk/for-the-public/online/cookies/">find out more about cookies and how to delete them on the Information Commissioner's Office (ICO) website.</a></p>
+


### PR DESCRIPTION
This PR updates the cookies preference page copy so that it matches the [approved/signed off copy](https://docs.google.com/document/d/1bgTxlkAfkH_Sd5BDT55W62JHELO9kRIC2P1jnef-iBM/edit?tab=t.0#heading=h.u2qnk3gapkxa).  

It also moves all hardcoded text out of the erb file into the locales ahead of the incoming Welsh translations for the page