### PR TITLE
Chore: Update list of cookies

### DIFF
--- a/engine/lib/citizens_advice_cookie_preferences/version.rb
+++ b/engine/lib/citizens_advice_cookie_preferences/version.rb
@@ -22,7 +22,6 @@ module CitizensAdviceCookiePreferences
     "CustomizationObject" => "essential",
     "cwr_s" => "essential",
     "cwr_u" => "essential",
-    "eprivacy" => "essential",
     "lpLastVisit-*" => "essential",
     "lpPmCalleeDfs" => "essential",
     "LPSID-*" => "essential",
@@ -39,6 +38,7 @@ module CitizensAdviceCookiePreferences
     "mf_initialDomQueue" => "analytics",
     "mf_transmitQueue" => "analytics",
     "mf_user" => "analytics",
-    "mouseflow" => "analytics"
+    "mouseflow" => "analytics",
+    "ca_ab_*" => "analytics"
   }.freeze
 end


### PR DESCRIPTION
* Add `ca_ab_*` to the list of analytics cookies.  This is the new cookie name pattern the A/B testing approach that Chris has implemented in public-website will use
* Remove `eprivacy` from the list of essential cookies.  This is the cookie that is currently used to determine whether to render the cookie banner, or not, to users.  By removing it from the list it will mean that when we go live this cookie will be deleted from user's list, so we don't have to expire it, or find another way of deleting it