### PR TITLE
chore: Update Design System version

### DIFF
--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -28,7 +28,7 @@ gem "bootsnap", require: false
 # Pin to the same version as the npm package
 gem "citizens_advice_components",
     github: "citizensadvice/design-system",
-    tag: "v8.0.3",
+    tag: "v8.2.0",
     glob: "engine/*.gemspec"
 
 # This line is optional. The citizens_advice_components gem is built

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -22,11 +22,11 @@ GIT
 
 GIT
   remote: https://github.com/citizensadvice/design-system.git
-  revision: abea66c928ebe755372da567f5db8d339d3532ea
-  tag: v8.0.3
+  revision: 4b7c6f0bd9f315ea15438b4ab8a832f3bbccc71d
+  tag: v8.2.0
   glob: engine/*.gemspec
   specs:
-    citizens_advice_components (8.0.3)
+    citizens_advice_components (8.2.0)
       actionpack (>= 7.1.0, < 9.0)
       actionview (>= 7.1.0, < 9.0)
       activemodel (>= 7.1.0, < 9.0)
@@ -34,7 +34,7 @@ GIT
       activesupport (>= 7.1.0, < 9.0)
       rails-i18n (>= 7.0.10)
       railties (>= 7.1.0, < 9.0)
-      view_component (>= 2.0.0, < 4.0)
+      view_component (>= 2.0.0, < 5.0)
 
 PATH
   remote: ../engine
@@ -43,7 +43,7 @@ PATH
       citizens_advice_components (> 8.0.0)
       meta-tags
       rails (>= 7.1.0)
-      view_component (>= 2.0.0, < 4.0)
+      view_component (>= 2.0.0, < 5.0)
 
 GEM
   remote: https://rubygems.org/

--- a/engine/Gemfile
+++ b/engine/Gemfile
@@ -8,7 +8,7 @@ gemspec
 
 gem "citizens_advice_components",
     github: "citizensadvice/design-system",
-    tag: "v8.0.2",
+    tag: "v8.2.0",
     glob: "engine/*.gemspec"
 
 gem "puma"

--- a/engine/Gemfile.lock
+++ b/engine/Gemfile.lock
@@ -14,11 +14,11 @@ GIT
 
 GIT
   remote: https://github.com/citizensadvice/design-system.git
-  revision: 582b90893278a0ad3ec7e0e6b2e98a0901868565
-  tag: v8.0.2
+  revision: 4b7c6f0bd9f315ea15438b4ab8a832f3bbccc71d
+  tag: v8.2.0
   glob: engine/*.gemspec
   specs:
-    citizens_advice_components (8.0.2)
+    citizens_advice_components (8.2.0)
       actionpack (>= 7.1.0, < 9.0)
       actionview (>= 7.1.0, < 9.0)
       activemodel (>= 7.1.0, < 9.0)
@@ -26,7 +26,7 @@ GIT
       activesupport (>= 7.1.0, < 9.0)
       rails-i18n (>= 7.0.10)
       railties (>= 7.1.0, < 9.0)
-      view_component (>= 2.0.0, < 4.0)
+      view_component (>= 2.0.0, < 5.0)
 
 PATH
   remote: .
@@ -35,7 +35,7 @@ PATH
       citizens_advice_components (> 8.0.0)
       meta-tags
       rails (>= 7.1.0)
-      view_component (>= 2.0.0, < 4.0)
+      view_component (>= 2.0.0, < 5.0)
 
 GEM
   remote: https://rubygems.org/

--- a/engine/citizens_advice_cookie_preferences.gemspec
+++ b/engine/citizens_advice_cookie_preferences.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "citizens_advice_components", "> 8.0.0"
   spec.add_dependency "meta-tags"
   spec.add_dependency "rails", ">= 7.1.0"
-  spec.add_dependency "view_component", [">= 2.0.0", "< 4.0"]
+  spec.add_dependency "view_component", [">= 2.0.0", "< 5.0"]
 end


### PR DESCRIPTION
There has been a design system release which includes a bump to the view_component versions that it supports.  Public-website, amongst other repos, have updated their view_component version which means that we have to change the engine's view_component dependency versions to avoid compatibility issues