### PR TITLE
Cp 887 welsh build banner

### DIFF
--- a/engine/Gemfile
+++ b/engine/Gemfile
@@ -21,6 +21,7 @@ gem "sprockets-rails"
 group :development, :test do
   gem "brakeman", require: false
   gem "bundler-audit"
+  gem "capybara"
   gem "citizens-advice-style", github: "citizensadvice/citizens-advice-style-ruby", tag: "v12.0.0"
   gem "pry"
   gem "rspec-rails"

--- a/engine/Gemfile.lock
+++ b/engine/Gemfile.lock
@@ -111,6 +111,8 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.3)
     base64 (0.3.0)
     benchmark (0.4.1)
@@ -121,6 +123,15 @@ GEM
     bundler-audit (0.9.2)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
@@ -152,6 +163,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
+    matrix (0.4.3)
     meta-tags (2.22.1)
       actionpack (>= 6.0.0, < 8.1)
     method_source (1.1.0)
@@ -197,6 +209,7 @@ GEM
     psych (5.2.6)
       date
       stringio
+    public_suffix (6.0.2)
     puma (6.6.1)
       nio4r (~> 2.0)
     racc (1.8.1)
@@ -330,6 +343,8 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.7.3)
 
 PLATFORMS
@@ -345,6 +360,7 @@ PLATFORMS
 DEPENDENCIES
   brakeman
   bundler-audit
+  capybara
   citizens-advice-style!
   citizens_advice_components!
   citizens_advice_cookie_preferences!

--- a/engine/config/locales/cy.yml
+++ b/engine/config/locales/cy.yml
@@ -1,0 +1,30 @@
+---
+cy:
+  cookie_banner:
+    title: Cwcis ar ein gwefan
+    accept_button: Derbyn pob cwci ychwanegol
+    hide_button: Hide this message
+    reject_button: Gwrthod pob cwci ychwanegol
+    link: Dewiswch gwcis
+    accept_confirmation:
+      html: >
+        You’ve accepted additional cookies. You can
+        <a href="/cookie-preferences/">change your cookie settings</a>
+        at any time
+    reject_confirmation:
+      html: >
+        You’ve rejected additional cookies. You can
+        <a href="/cookie-preferences/">change your cookie settings</a>
+        at any time
+
+    description:
+      html: >
+        <p>Rydym yn defnyddio cwcis hanfodol i sicrhau bod ein gwefan yn gweithio'n iawn.</p>
+        <p>Hoffem hefyd ddefnyddio cwcis ychwanegol er mwyn cofio eich gosodiadau a deall sut rydych chi'n defnyddio ein gwefan. Mae hyn yn ein helpu ni i wella ein gwasanaethau ar eich cyfer chi.</p>
+        <p>Mae cwcis ychwanegol yn dod o wefannau eraill. Mae'r cwcis hyn yn ein helpu i ddangos pethau i chi o'r gwefannau hynny, fel fideos.</p>
+        <p>Gallwch <a href="%{page_url}">ddysgu mwy am y cwcis rydym yn eu defnyddio</a>.</p>
+    no_js_banner_html: >
+      <p>Mae'n ymddangos bod JavaScript i ffwrdd gennych. Mae angen i chi dderbyn neu wrthod cwcis ar ein gwefan.</p>
+      <p>Gan ei fod i ffwrdd, byddwn ddim ond yn defnyddio'r cwcis hanfodol y mae ein gwefan eu hangen i weithio. Mae hyn yn golygu y gallai rhai pethau, fel fideos, ddim gweithio i chi.</p>
+      <p>Gallwch <a href="%{page_url}">ddysgu mwy am y cwcis rydym yn eu defnyddio</a>.</p>
+    no_js_button: Cau'r neges hon

--- a/engine/spec/components/citizens_advice_cookie_preferences/cookie_banner_spec.rb
+++ b/engine/spec/components/citizens_advice_cookie_preferences/cookie_banner_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CitizensAdviceCookiePreferences::CookieBanner, type: :component do
+  subject { page }
+
+  let(:component) { described_class.new }
+
+  before do
+    allow(component).to receive_messages(how_we_use_cookies_url: "/some-url", pref_page_url: "/some-other-url")
+    render_inline(component)
+  end
+
+  describe "CookieBanner" do
+    context "when English language" do
+      it { is_expected.to have_text "Cookies on Citizens Advice" }
+    end
+
+    context "when Welsh language" do
+      around { |example| I18n.with_locale(:cy) { example.run } }
+
+      it { is_expected.to have_text "Cwcis ar ein gwefan" }
+    end
+  end
+end

--- a/engine/spec/rails_helper.rb
+++ b/engine/spec/rails_helper.rb
@@ -8,8 +8,11 @@ require_relative "test_app/config/environment"
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 
 require "rspec/rails"
+require "view_component/test_helpers"
 
 RSpec.configure do |config|
+  config.include ViewComponent::TestHelpers, type: :component
+
   # To enable this behaviour uncomment the line below.
   config.infer_spec_type_from_file_location!
 


### PR DESCRIPTION
This PR adds the Welsh translation to the cookie banner. It doesn't change the component files so there are no changes required in the host apps (other than updating the gem).

There is a separate ticket for adding Welsh to the cookie preferences page which will require more changes.