### PR TITLE
feat: adding an ADR for the need of handing SCSS and JS via npm package

### DIFF
--- a/engine/docs/architecture-decisions/002-npm-package.md
+++ b/engine/docs/architecture-decisions/002-npm-package.md
@@ -4,7 +4,7 @@ Date: 2025-09-10
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -75,4 +75,7 @@ Cons:
 
 ## Decision
 
-TBD
+We have decided to go with Option 1 - continue using the current process.
+Handling two release processes will add unnecessary complexity.
+Unlike the design system, the SCSS and JS for the cookie preferences gem is a key part of the engine and meant to always be used with together with it.
+Our projects use mixture of Sprockets and Propshaft, but when we move to Propshaft consistently, it will be even easier to import SCSS and JS.


### PR DESCRIPTION
We have decided not to go ahead with making an npm package for handling SCSS and JS for the cookie preferences engine.
This PR documents the decision. 
Related to [CP-896](https://citizensadvice.atlassian.net/browse/CP-896)

[CP-896]: https://citizensadvice.atlassian.net/browse/CP-896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ