### PR TITLE
[CP-927] Don't delete malformed cookies

### DIFF
--- a/engine/app/models/citizens_advice_cookie_preferences/cookie_management.rb
+++ b/engine/app/models/citizens_advice_cookie_preferences/cookie_management.rb
@@ -12,6 +12,7 @@ module CitizensAdviceCookiePreferences
     def delete_unconsented_cookies!
       cookies.each do |cookie, _|
         next if permitted_cookie?(cookie)
+        next if malformed_cookie?(cookie)
 
         cookies.delete(cookie, domain: :all)
       end
@@ -30,6 +31,10 @@ module CitizensAdviceCookiePreferences
           cookie.start_with?(start_string) && wildcard_cookie_category.in?(consented_categories)
         end
       end
+    end
+
+    def malformed_cookie?(cookie)
+      CGI.unescape(cookie) != cookie
     end
 
     def wildcard_cookies

--- a/engine/spec/models/citizens_advice_cookie_preferences/cookie_management_spec.rb
+++ b/engine/spec/models/citizens_advice_cookie_preferences/cookie_management_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe CitizensAdviceCookiePreferences::CookieManagement do
       ethnio_displayed: "something",
       _ga_wildcard: "something",
       cookie_preference: { essential: true, analytics: false }.to_json,
-      evil_tracking_cookie: "muhaha"
+      evil_tracking_cookie: "muhaha",
+      "16%20Sep%202026%2009:50:40%20GMT": "ouch"
     }
   end
 
@@ -28,6 +29,10 @@ RSpec.describe CitizensAdviceCookiePreferences::CookieManagement do
 
   it "deletes unexpected cookies" do
     expect(cookie_management).not_to include("evil_tracking_cookie")
+  end
+
+  it "does not delete malformed cookies" do
+    expect(cookie_management).to include("16%20Sep%202026%2009:50:40%20GMT")
   end
 
   context "when a user has consented to analytics cookies" do


### PR DESCRIPTION
After deploying the new cookie code to production, we started seeing random HTTP 500s from bots and other places that were triggering alerts.

These requests all seemed to include a cookie whose name was URL-encoded. When our code attempted to delete this cookie (by setting an expiring `Set-Cookie` header in the response), it was triggering an exception that caused this error.

Because no legitimate user should be given URL-encoded cookies by us (I've certainly never seen it, even when Episerver was still around), I've amended the cookie deletion code to skip over these.