### PR TITLE
fix: changing the heading level of analytics and video player cookies

### DIFF
--- a/engine/config/locales/cy.yml
+++ b/engine/config/locales/cy.yml
@@ -53,7 +53,7 @@ cy:
       <p>Fyddwn ni ddim yn ychwanegu cwcis ychwanegol heb eich caniatâd chi.</p>
     form:
       analytic_cookies_header_html: >
-        <h2>Cwcis dadansoddi</h2>
+        <h3>Cwcis dadansoddi</h3>
       analytic_cookies_options:
         accept: Derbyn cwcis dadansoddi
         reject: Gwrthod cwcis dadansoddi
@@ -61,7 +61,7 @@ cy:
         <p>Mae'r cwcis hyn yn ein helpu ni i wella ein gwefan drwy ddangos sut mae pobl yn ei defnyddio. Er enghraifft, pa dudalennau sydd fwyaf poblogaidd neu lle mae pobl yn cael trafferth.</p> 
         <p>Rydym yn defnyddio teclynnau fel Google Analytics a Mouseflow i weld sut mae pobl yn defnyddio ein gwefan.</p>
       video_player_cookies_header_html: >
-        <h2>Cwcis chwaraewyr fideo</h2>
+        <h3>Cwcis chwaraewyr fideo</h3>
       video_player_cookies_options:
         accept: Derbyn cwcis chwaraewr fideo
         reject: Gwrthod cwcis chwaraewr fideo

--- a/engine/config/locales/en.yml
+++ b/engine/config/locales/en.yml
@@ -52,7 +52,7 @@ en:
       <p>We won't add additional cookies unless you give us permission.</p>
     form:
       analytic_cookies_header_html: >
-        <h2>Analytics cookies</h2>
+        <h3>Analytics cookies</h3>
       analytic_cookies_options:
         accept: Accept analytics cookies
         reject: Reject analytics cookies
@@ -60,7 +60,7 @@ en:
         <p>These cookies help us improve our website by showing us how people use it. For example, which pages are most popular or where people are having problems.</p> 
         <p>We use tools like Google Analytics and Mouseflow to see how people are using our site.</p>
       video_player_cookies_header_html: >
-        <h2>Video player cookies</h2>
+        <h3>Video player cookies</h3>
       video_player_cookies_options:
         accept: Accept video players cookies
         reject: Reject video players cookies


### PR DESCRIPTION
Changing from h2 to h3 as they are part of "Additional cookies" section.