### PR TITLE
Adding demo rspec to the github actions pipeline

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -112,6 +112,22 @@ jobs:
           path: demo/log/cucumber_report.*
           retention-days: 7
 
+  test-demo-app:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: demo
+    needs: lint-demo-app
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v5
+
+      - name: "Install dependencies"
+        uses: ./.github/actions/install-demo-dependencies
+
+      - name: "Rspec"
+        run: bundle exec rspec
+
   test-engine:
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -127,10 +127,3 @@ jobs:
 
       - name: "Rspec"
         run: bundle exec rspec
-
-    services:
-      standalone-firefox:
-        image: selenium/standalone-firefox
-        options: --shm-size=2gb
-        ports:
-          - "4444:4444"

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -125,6 +125,9 @@ jobs:
       - name: "Install dependencies"
         uses: ./.github/actions/install-demo-dependencies
 
+      - name: "Precompile assets"
+        run: bundle exec rails assets:precompile
+
       - name: "Rspec"
         run: bundle exec rspec
 


### PR DESCRIPTION
We have some tests as part of the demo app and we'll be adding more with the return url feature. This PR adds the demo app tests in the github actions pipeline