### PR TITLE
Bump rack from v3.2.5 to v3.2.6

### DIFF
--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -289,7 +289,7 @@ GEM
     puma (7.2.0)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.2.5)
+    rack (3.2.6)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)


### PR DESCRIPTION
I previously bumped the version under `engine/`, this also bumps the version under `demo/`